### PR TITLE
[MAINTENACE] 감정 표현 상수를 배열에서 객체로 수정하여 보여지는 값(UI)은 key 값으로 서버에 전달되는 값은 value 값으로 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 
+# env 파일
 .env
+.env.*

--- a/src/components/diary/emotionSelectorModal.tsx
+++ b/src/components/diary/emotionSelectorModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Emotion, emotions } from "../../contants/emtionsContants";
+import { Emotion, EmotionKey, emotions } from "../../contants/emtionsContants";
 
 
 
@@ -17,15 +17,17 @@ const EmotionSelectorModal: React.FC<EmotionSelectorModalProps> = ({
   const [currentEmotion, setCurrentEmotion] = useState<Emotion | null>(selectedEmotion);
 
   // 감정 선택 함수
-  const selectEmotion = (emotion: Emotion) => {
-    setCurrentEmotion(emotion); // 선택한 감정을 설정
+  const selectEmotion = (emoji: EmotionKey) => {
+    const emotionValue:Emotion = emotions[emoji];
+    setCurrentEmotion(emotionValue); // 선택한 감정을 설정
+    console.log("선택된 감정: ", emotionValue);
   };
 
   // 저장 버튼 클릭 시 실행
   const handleSave = () => {
     if (currentEmotion) {
-      onSelect(currentEmotion); // 부모 컴포넌트에 선택된 감정을 전달
-      onClose(); // 모달 닫기
+      onSelect(currentEmotion); // ✅ 감정명을 부모 컴포넌트에 전달
+      onClose();
     }
   };
 
@@ -55,10 +57,10 @@ const EmotionSelectorModal: React.FC<EmotionSelectorModalProps> = ({
       >
         <h3>감정 표현 선택</h3>
         <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
-          {emotions.map((emotion) => (
+          {Object.entries(emotions).map(([emoji, emotion]) => (
             <button
-              key={emotion}
-              onClick={() => selectEmotion(emotion)}
+              key={emoji}
+              onClick={() => selectEmotion(emoji as EmotionKey)}
               style={{
                 padding: "8px 16px",
                 border: "none",
@@ -68,7 +70,7 @@ const EmotionSelectorModal: React.FC<EmotionSelectorModalProps> = ({
                 cursor: "pointer",
               }}
             >
-              {emotion}
+              {emoji}
             </button>
           ))}
         </div>

--- a/src/contants/emtionsContants.tsx
+++ b/src/contants/emtionsContants.tsx
@@ -1,13 +1,20 @@
 // 감정 표현 상수 및 타입 정의
-export const emotions = [
-  "😊", // 행복
-  "😢", // 슬픔
-  "😡", // 분노
-  "😱", // 두려움
-  "🤔", // 관심
-  "🫢", // 놀라움
-  "😒", // 혐오
-  "😳", // 수치심
-] as const;
+export const emotions = {
+  "😊": "HAPPINESS", // 행복
+  "😢": "SADNESS", // 슬픔
+  "😡": "ANGER", // 분노
+  "😱": "FEAR", // 두려움
+  "🤔": "INTEREST", // 관심
+  "🫢": "SURPRISE", // 놀라움
+  "😒": "DISGUST", // 혐오
+  "😳": "SHAME", // 수치심
+} as const;
 
-export type Emotion = typeof emotions[number];
+// 감정 키(이모지) 타입
+export type EmotionKey = keyof typeof emotions;
+
+// 감정 값 (감정명) 타입
+export type EmotionValue = typeof emotions[EmotionKey];
+
+// Emotion은 감정 값만 저장
+export type Emotion = EmotionValue;

--- a/src/pages/createDiary.tsx
+++ b/src/pages/createDiary.tsx
@@ -6,7 +6,7 @@ import MyDropzone from "../components/diary/addImage";
 import EmotionSelectorModal from "../components/diary/emotionSelectorModal";
 import { useNavigate } from "react-router-dom";
 import { DiaryService } from "../services/diary/DiaryService";
-import { Emotion } from "../contants/emtionsContants";
+import { emotions, Emotion, EmotionKey } from "../contants/emtionsContants";
 import { tags } from "../contants/tagsContants";
 
 const CreateDiaryPage: React.FC = () => {
@@ -38,13 +38,17 @@ const CreateDiaryPage: React.FC = () => {
   if (!date) return; // null 값 처리
 
   // KST 시간대로 날짜 format
-  const formatDate = `${date.getFullYear()}-${(date.getMonth() + 1)
-    .toString()
-    .padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;
+  const formatDate = `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;
+    setSelectedDate(date);
+    navigate(`/diaries/new/${formatDate}`);
+  };
 
-  setSelectedDate(date);
-  navigate(`/diaries/new/${formatDate}`);
-};
+  // 감정명을 이모지 변환
+  const getEmojiFromEmotion = (emotion:Emotion | null) => {
+    return Object.keys(emotions).find(
+      (emoji) => emotions[emoji as EmotionKey] === emotion
+    ) || "";
+  };
 
   const handleSaveTags = (tags: string[]) => {
     setSelectedTags(tags);
@@ -109,7 +113,7 @@ const CreateDiaryPage: React.FC = () => {
         <h3>감정 표현:</h3>
         <div>
           <span style={{ fontSize: "22px" }}>
-            {selectedEmotion || <p>감정을 선택해주세요</p>}
+            {selectedEmotion ? getEmojiFromEmotion(selectedEmotion) : <p>감정을 선택해주세요</p>}
           </span>
           <button onClick={() => setIsEmotionModalOpen(true)} style={{ marginLeft: "10px" }}>
             감정 선택


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #23 

## #️⃣ 작업 내용

> - 배열로 되어있던 감정 표현 상수를 객체로 수정하여 key-value값으로 설정
> - emotion의 key, value 따로 타입을 나누어서 modal 및, createDiary에 타입 설정 ( as EmotionKey 등)
> - modal에서 emoji로 전달 받은 key를 value 값으로 변환해주는 함수 추가

## #️⃣ 테스트 결과

><img width="663" alt="image" src="https://github.com/user-attachments/assets/852f078b-31e3-4f5e-9d5a-564b28d8ffba" />


## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
