### PR TITLE
[FEATRUE] 이미지 첨부 관련 API 생성 및 다른 API 관리

### DIFF
--- a/src/pages/createDiary.tsx
+++ b/src/pages/createDiary.tsx
@@ -67,6 +67,25 @@ const CreateDiaryPage: React.FC = () => {
 
   const handleAddImage = (file: File) => {
     setUploadedImages((prevImages) => [...prevImages, file]);
+
+    // 허용할 이미지 용량 및 확장자
+    const imageMaxSize = 10 * 1024 * 1024; // 10MB
+    //const allowFileExtension = ["jpeg","jpg","png"];
+
+    // 확장자 확인
+    // if(!allowFileExtension(file)) {
+    //   alert("업로드 가능한 확장자가 아닙니다.[ 가능한 확장자 : ", ${allowFileExtension}, " ] ")
+    // }
+
+    // 이미지 용량 확인
+    if(file.size > imageMaxSize){
+      alert(`업로드 가능한 최대 용량은 10MB입니다. (현재 파일 용량 : ${(file.size / (1024 * 1024)).toFixed(2)}MB)`);
+      return;
+    } 
+
+    // 전달할 API
+    const response = DiaryService.imageUpload(file);
+    console.log(`IMAGE response: ${response}`);
   };
 
   const handleDeleteImage = (index: number) => {
@@ -91,7 +110,6 @@ const CreateDiaryPage: React.FC = () => {
         emotion: selectedEmotion,
         content: content,
         tags: selectedTags,
-        image: uploadedImages.length > 0 ? uploadedImages[0].name : undefined,
       };
 
       console.log(`diary: ${JSON.stringify(diary)}`);
@@ -101,7 +119,7 @@ const CreateDiaryPage: React.FC = () => {
 
       console.log(`response: ${response}`);
 
-      if (!response || !response.success) {
+      if (!response) {
         throw new Error('일기가 등록되지않았습니다.');
       }
 
@@ -183,6 +201,7 @@ const CreateDiaryPage: React.FC = () => {
           {uploadedImages.map((file, index) => (
             <li key={index} style={{ display: 'flex', alignItems: 'center' }}>
               {file.name}
+              {(file.size / (1024 * 1024)).toFixed(2)}MB
               <button
                 onClick={() => handleDeleteImage(index)}
                 style={{ marginLeft: '10px' }}

--- a/src/pages/viewDiaryPage.tsx
+++ b/src/pages/viewDiaryPage.tsx
@@ -2,27 +2,6 @@ import React, { useEffect, useState } from "react";
 import { Diary, DiaryService } from "../services/diary/DiaryService";
 import { useNavigate, useParams } from "react-router-dom";
 
-// Mock 데이터 생성
-// const mockDiary: Diary = {
-//   date: "2025-1-14",
-//   emotion: "😊", // 감정 표현
-//   content: "오늘은 정말 즐거운 하루를 보냈어요!", // 일기 내용
-//   tags: ["운동", "독서"], // 태그 목록
-//   imageId: 1,
-//   imageUrl: "https://dummyimage.com/300x200/000/fff", // 대체 샘플 이미지 URL
-// };
-
-// Mock DiaryService
-// const MockDiaryService = {
-//   getDiaryByDate: async (date: string): Promise<Diary> => {
-//     console.log(`Mock 호출 - 날짜: ${date}`);
-//     if (date === mockDiary.date) {
-//       return mockDiary;
-//     }
-//     throw new Error("Mock: 일기를 찾을 수 없습니다.");
-//   },
-// };
-
 const DiaryDetail: React.FC = () => {
   const { date } = useParams<{ date: string }>(); // URL 파라미터에서 date 가져오기
   const [diary, setDiary] = useState<Diary | null>(null);
@@ -47,6 +26,14 @@ const DiaryDetail: React.FC = () => {
 
     fetchDiary();
   }, [date]);
+
+  // 일기를 찾을 수 없을 경우 생성페이지로 이동
+  useEffect(() => {
+    if(error === "일기를 가져오는 데 실패했습니다."){
+      alert("해당 날짜의 일기가 존재하지않습니다. 새로운 일기를 작성해주세요.");
+      navigate(`/diaries/new/${date}`);
+    }
+  }, [error, navigate, date]);  // 의존성 배열을 추가함으로써 불필요한 렌더링 방지
 
   const updateDiary = () =>{
     navigate(`/diaries/view/:date`);
@@ -74,19 +61,16 @@ const DiaryDetail: React.FC = () => {
           <p><strong>감정 표현:</strong> {diary.emotion}</p>
           <p><strong>내용:</strong> {diary.content || "내용이 없습니다."}</p>
           <p><strong>태그:</strong> {diary.tags?.join(", ") || "태그가 없습니다."}</p>
-          {diary.imageUrl && (
+          { diary.imageUrl ? (
             <div>
               <strong>이미지:</strong>
               <img src={diary.imageUrl} alt="Diary" style={{ maxWidth: "300px", marginTop: "10px" }} />
             </div>
-          )}
-
+          ) : null}
           <button onClick={updateDiary}>수정하기</button>
           <button onClick={deleteDiary}>삭제하기</button>
         </>
-      ) : (
-        <p>일기를 찾을 수 없습니다.</p>
-      )}
+      ): null}
     </div>
   );
 };

--- a/src/services/diary/DiaryService.tsx
+++ b/src/services/diary/DiaryService.tsx
@@ -15,6 +15,12 @@ export interface Diary {
   imageUrl?: string;
 }
 
+// 이미지 업로드 응답 타입 정의
+interface ImageUploadResponse {
+  imageUrl : string;
+}
+
+// 토큰 관리
 const token = localStorage.getItem('Authorization');
 
 // DiaryService 정의
@@ -22,9 +28,9 @@ export const DiaryService = {
   // 프로필 조회
   getName: async () => {
     try {
-      const response = await axios.get<{ name: string }>(
+      const response = await axios.get(
         `${API_SERVER_URL}/user/profile`
-      ); // <{ name: string }> : API 응답 데이터의 구조 정의
+      );
       return response.data;
     } catch {
       console.log('API : 프로필 조회에 실패하였습니다.');
@@ -34,32 +40,59 @@ export const DiaryService = {
   // 일기 생성
   createDiary: async (diary: Diary, date: string) => {
     try {
+      // josn 데이터 전송
+      const diaryData = {
+        date : diary.date,
+        emotion : diary.emotion,
+        conteent : diary.content,
+        tags : diary.tags,
+      };
+
+      const response = await axios.post(
+        `${API_SERVER_URL}/diaries/${date}`,
+        diaryData,
+        {
+          headers: {
+            Authorization: token,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      console.log("생성 : ",response.data);
+      return response.data;
+    } catch {
+      console.log('API : 일기 생성에 실패하였습니다.');
+      console.log(`${API_SERVER_URL}/diaries/${date}`); // URL 확인
+    }
+  },
+
+  // 이미지 첨부
+  imageUpload: async (imageFile: File, setImageUrl : (url:string) => void) => {
+    try{
       // 이미지 format
       const formData = new FormData();
-      formData.append('date', diary.date);
-
-      if (diary.imageFile) {
-        formData.append('image', diary.imageFile); // 파일 객체 추가
-      }
+        formData.append('image', imageFile); // 파일 객체 추가
 
       formData.forEach((value, key) => {
         console.log(`${key}: ${value}`);
       });
 
-      const response = await axios.post<{ success: boolean }>(
-        `${API_SERVER_URL}/diaries/${date}`,
-        diary,
-        {
-          headers: {
-            Authorization: token,
-            'Content-Type': 'multipart/form-data',
-          },
-        }
-      );
-      return response.data;
+      const response = await axios.post<ImageUploadResponse>(`${API_SERVER_URL}/diaries/images`, formData, {
+        headers: {
+          Authorization: token,
+          'Content-Type':'multipart/form-data'
+        },
+      });
+
+      console.log("이미지 첨부 : ",response.data);
+      
+      // 응답 받은 URL을 저장
+      setImageUrl(response.data.imageUrl);
+
+      return response.data.imageUrl;
+
     } catch {
-      console.log('API : 일기 생성에 실패하였습니다.');
-      console.log(`${API_SERVER_URL}/diaries/${date}`); // URL 확인
+      console.log('API : 이미지 첨부에 실패하였습니다.');
     }
   },
 
@@ -85,7 +118,7 @@ export const DiaryService = {
   updateDiary: async (date: string, updateDiary: Partial<Diary>) => {
     // Partial<Diary> : Diary 타입의 모든 속성을 필수에서 선택으로 변경됨
     try {
-      const response = await axios.put<{ success: boolean }>(
+      const response = await axios.put(
         `${API_SERVER_URL}/diaries/${date}`,
         updateDiary,
         {
@@ -94,7 +127,8 @@ export const DiaryService = {
             'Content-Type': 'application/json',
           },
         }
-      ); // <{ success: boolean }> : 응답 데이터 구조 정의
+      );
+      console.log("수정 : ",response.data);
       return response.data;
     } catch {
       console.log('API : 일기 수정에 실패하였습니다.');
@@ -104,7 +138,7 @@ export const DiaryService = {
   // 일기 삭제
   deleteDiary: async (date: string) => {
     try {
-      const response = await axios.delete<{ success: boolean }>(
+      const response = await axios.delete(
         `${API_SERVER_URL}/diaries/${date}`,
         {
           headers: {
@@ -113,6 +147,7 @@ export const DiaryService = {
           },
         }
       );
+      console.log("삭제 : ",response.data);
       return response.data;
     } catch {
       console.log('API : 일기 삭제에 실패하였습니다.');


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #22 

## #️⃣ 작업 내용

> - 이미지 업로드 응답 타입 정의
- 일기 생성에 전송할 json 데이터 생성
- 이미지 업로드 API 생성
- 조회 페이지에서 imageUrl 로 이미지 출력
- 일기 조회 시 일기 존재하지 않을 경우 일기 생성페이지로 이동

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
