### PR TITLE
[REFACTOR] 서버에 imageUrl 값을 전달 및 태그에 관련된 400 error 수정

### DIFF
--- a/src/pages/createDiary.tsx
+++ b/src/pages/createDiary.tsx
@@ -26,6 +26,8 @@ const CreateDiaryPage: React.FC = () => {
   // image
   const [uploadedImages, setUploadedImages] = useState<File[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  // imageUrl
+  const [uploadedImageUrl, setUploadedImageUrl] = useState<string[]>([]);
   // error
   const [error, setError] = useState<string | null>(null);
   // router
@@ -65,7 +67,7 @@ const CreateDiaryPage: React.FC = () => {
     setSelectedTags(selectedTags.filter((t) => t !== tag));
   };
 
-  const handleAddImage = (file: File) => {
+  const handleAddImage = async(file: File) => {
     setUploadedImages((prevImages) => [...prevImages, file]);
 
     // 허용할 이미지 용량 및 확장자
@@ -83,9 +85,17 @@ const CreateDiaryPage: React.FC = () => {
       return;
     } 
 
-    // 전달할 API
-    const response = DiaryService.imageUpload(file);
-    console.log(`IMAGE response: ${response}`);
+    // 이미지 업로드 API
+    try{
+      const imageUrl = await DiaryService.imageUpload(file);
+      if (imageUrl){
+        setUploadedImageUrl((prevUrls) => [...prevUrls, imageUrl]);
+        setUploadedImages((prevImages) => [...prevImages, file]);
+      }
+    } catch (error){
+      console.error('이미지 업로드 실패:', error);
+      alert('이미지 업로드 중 오류가 발생했습니다.');
+    }
   };
 
   const handleDeleteImage = (index: number) => {
@@ -109,7 +119,8 @@ const CreateDiaryPage: React.FC = () => {
         date: selectedDate.toISOString().split('T')[0],
         emotion: selectedEmotion,
         content: content,
-        tags: selectedTags,
+        tag: selectedTags,
+        imageUrl: uploadedImageUrl.join(','),
       };
 
       console.log(`diary: ${JSON.stringify(diary)}`);

--- a/src/pages/viewDiaryPage.tsx
+++ b/src/pages/viewDiaryPage.tsx
@@ -57,10 +57,10 @@ const DiaryDetail: React.FC = () => {
     <div style={{ padding: "20px" }}>
       {diary ? (
         <>
-          <h2>{diary.date}</h2>
+          <h2>{date}</h2>
           <p><strong>감정 표현:</strong> {diary.emotion}</p>
           <p><strong>내용:</strong> {diary.content || "내용이 없습니다."}</p>
-          <p><strong>태그:</strong> {diary.tags?.join(", ") || "태그가 없습니다."}</p>
+          <p><strong>태그:</strong> {diary.tag?.join(", ") || "태그가 없습니다."}</p>
           { diary.imageUrl ? (
             <div>
               <strong>이미지:</strong>

--- a/src/services/diary/DiaryService.tsx
+++ b/src/services/diary/DiaryService.tsx
@@ -7,10 +7,9 @@ export const API_SERVER_URL =
 
 // Diary 타입 정의
 export interface Diary {
-  date: string;
   emotion: string;
   content?: string;
-  tags: string[];
+  tag: string[];
   imageFile?: File;
   imageUrl?: string;
 }
@@ -42,10 +41,10 @@ export const DiaryService = {
     try {
       // josn 데이터 전송
       const diaryData = {
-        date : diary.date,
         emotion : diary.emotion,
         conteent : diary.content,
-        tags : diary.tags,
+        tag : diary.tag,
+        imageUrl : diary.imageUrl,
       };
 
       const response = await axios.post(
@@ -67,11 +66,11 @@ export const DiaryService = {
   },
 
   // 이미지 첨부
-  imageUpload: async (imageFile: File, setImageUrl : (url:string) => void) => {
+  imageUpload: async (imageFile: File) => {
     try{
       // 이미지 format
       const formData = new FormData();
-        formData.append('image', imageFile); // 파일 객체 추가
+        formData.append('file', imageFile); // 파일 객체 추가
 
       formData.forEach((value, key) => {
         console.log(`${key}: ${value}`);
@@ -85,10 +84,6 @@ export const DiaryService = {
       });
 
       console.log("이미지 첨부 : ",response.data);
-      
-      // 응답 받은 URL을 저장
-      setImageUrl(response.data.imageUrl);
-
       return response.data.imageUrl;
 
     } catch {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #32 

## #️⃣ 작업 내용

> - imageUpload에 있던 매개변수 삭제
> - 일기 생성에 필요한 data에 imageUrl 추가
> - Diary interface에서 tags를 tag로 수정하여 서버에 전달할 수 있도록 구현
> - 일기 생성 페이지에서 이미지 첨부 시 서버에 전달하는 이미지와 서버에서 받은 응답값을 동시에 저장
> - 일기 조회 페이지에서 imageUpload POST의 받아온 응답값으로 이미지 출력

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
